### PR TITLE
子パッケージをgraceful{http,grpc}にリネームする

### DIFF
--- a/gracefulgrpc/server.go
+++ b/gracefulgrpc/server.go
@@ -1,5 +1,5 @@
-// Package grpc provides utilities for go-graceful.
-package grpc
+// Package gracefulgrpc provides utilities for go-graceful.
+package gracefulgrpc
 
 import (
 	"context"

--- a/gracefulgrpc/server_test.go
+++ b/gracefulgrpc/server_test.go
@@ -1,0 +1,1 @@
+package gracefulgrpc

--- a/gracefulhttp/server.go
+++ b/gracefulhttp/server.go
@@ -1,5 +1,5 @@
-// Package http provides utilities for go-graceful.
-package http
+// Package gracefulhttp provides utilities for go-graceful.
+package gracefulhttp
 
 import (
 	"context"

--- a/gracefulhttp/server_test.go
+++ b/gracefulhttp/server_test.go
@@ -1,0 +1,1 @@
+package gracefulhttp

--- a/grpc/server_test.go
+++ b/grpc/server_test.go
@@ -1,1 +1,0 @@
-package grpc

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -1,1 +1,0 @@
-package http


### PR DESCRIPTION
例えばhttpの場合、実際に使うときはこのようになる。

```go
import ghttp "github.com/ne-sachirou/go-graceful/http"

ghttp.Server{
    Server: http.Server{
        Addr: ":8080",
        Handler: mux,
    },
}
```

**go-graceful/http** だと **net/http** と被っていて、常にパッケージ名を指定する必要があって面倒なので、被らない名前にしておくほうが便利かなと思いました。Goでは習慣的に **net/http/httptest** とか **io/ioutil** など親パッケージ名に続けて名前をつけているので、それに沿ってつけました。