### PR TITLE
gracefulOpts を unexport

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -22,33 +22,36 @@ type Servers struct {
 	Servers []Server
 }
 
-// GracefulOpts represents configuration parameters for the Server.
-// In default, GracefulOpts.Signals is []os.Signal{os.Interrupt} and GracefulOpts.ShutdownTimeout is 0.
-type GracefulOpts struct {
+// gracefulOpts represents configuration parameters for the Server.
+// In default, gracefulOpts.Signals is []os.Signal{os.Interrupt} and gracefulOpts.ShutdownTimeout is 0.
+type gracefulOpts struct {
 	Signals         []os.Signal
 	ShutdownTimeout time.Duration
 }
 
-func defaultGracefulOpts() GracefulOpts {
-	return GracefulOpts{
+func defaultGracefulOpts() gracefulOpts {
+	return gracefulOpts{
 		Signals:         []os.Signal{syscall.SIGINT, syscall.SIGTERM},
 		ShutdownTimeout: 0,
 	}
 }
 
+// Option applies an option to the Server.
+type Option func(*gracefulOpts)
+
 // GracefulSignals sets signals to be received.
-func GracefulSignals(signals ...os.Signal) func(*GracefulOpts) {
-	return func(o *GracefulOpts) { o.Signals = signals }
+func GracefulSignals(signals ...os.Signal) Option {
+	return func(o *gracefulOpts) { o.Signals = signals }
 }
 
 // GracefulShutdownTimeout sets timeout for shutdown.
-func GracefulShutdownTimeout(timeout time.Duration) func(*GracefulOpts) {
-	return func(o *GracefulOpts) { o.ShutdownTimeout = timeout }
+func GracefulShutdownTimeout(timeout time.Duration) Option {
+	return func(o *gracefulOpts) { o.ShutdownTimeout = timeout }
 }
 
 // Graceful runs all servers contained in s, then waits signals.
-// When receive an expected signal, s stops all servers gracefully.
-func (s Servers) Graceful(ctx context.Context, options ...func(*GracefulOpts)) error {
+// When receive an expected signal (in default, os.Interrupt), s stops all servers gracefully.
+func (s Servers) Graceful(ctx context.Context, options ...Option) error {
 	opts := defaultGracefulOpts()
 	for _, f := range options {
 		f(&opts)

--- a/gracefulgrpc/server.go
+++ b/gracefulgrpc/server.go
@@ -43,7 +43,7 @@ func ListenAndServe(
 	ctx context.Context,
 	addr string,
 	server *grpc.Server,
-	options ...func(*graceful.GracefulOpts),
+	options ...graceful.Option,
 ) error {
 	srv := graceful.Servers{Servers: []graceful.Server{&Server{Addr: addr, Server: server}}}
 	return srv.Graceful(ctx, options...)

--- a/gracefulhttp/server.go
+++ b/gracefulhttp/server.go
@@ -29,7 +29,7 @@ func ListenAndServe(
 	ctx context.Context,
 	addr string,
 	handler http.Handler,
-	options ...func(*graceful.GracefulOpts),
+	options ...graceful.Option,
 ) error {
 	httpSrv := &http.Server{
 		Addr:    addr,


### PR DESCRIPTION
GracefulOpts は GracefulSignals と GracefulTimeout を経由しないと設定できないので、 public にする意味なかったです。 unexport するようにしました。