### PR TITLE
Renovateのpatch更新を除外

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,13 +5,15 @@
   minimumReleaseAge: "3 days",
   packageRules: [
     {
-      automerge: true,
+      description: "Ignore non-security patch updates",
+      enabled: false,
       matchUpdateTypes: ["patch"],
     },
   ],
   schedule: "after 10am and before 7pm every weekday",
   timezone: "Asia/Tokyo",
   vulnerabilityAlerts: {
+    enabled: true,
     labels: ["dependencies", "security"],
   },
 }


### PR DESCRIPTION
通常のpatch更新ではPRを作成しないようにします。
脆弱性に起因する更新PRは引き続き作成します。